### PR TITLE
Correct definition of membrane distance in transit model

### DIFF
--- a/+MonteCarlo/@ParticleWalker/private/one_dt.m
+++ b/+MonteCarlo/@ParticleWalker/private/one_dt.m
@@ -124,18 +124,26 @@ end
 function distance = computeNormalDistance(faceVertices, step)
 % Find the projected distance in the normal direction to the plane
 
+% get the face normal
 V1 = faceVertices(1, :);
 V2 = faceVertices(2, :);
 V3 = faceVertices(3, :);
 edge01 = V2 - V1;
 edge02 = V3 - V1;
 normal = Geometry.crossFast2(edge01, edge02);
+
+% compute the dot product using normalised vectors
 normal = normal/norm(normal, 2);
 step_normalized = step/norm(step, 2);
-angle_between_vectors = acos(dot(step_normalized, normal));
-if angle_between_vectors >= pi/2
-    angle_between_vectors = pi - angle_between_vectors;
-end
-distance = norm(step,2)*cos(angle_between_vectors);
+dotproduct = dot(step_normalized, normal);
+
+% determine the distance
+%{
+theta = acos(dotproduct);
+if theta >= pi/2, theta = pi - theta; end
+t = cos(theta);
+%}
+t = abs(dotproduct); % this is the equivalent of the commented code above
+distance = norm(step,2)*t;
 
 end

--- a/+MonteCarlo/@ParticleWalker/private/one_dt.m
+++ b/+MonteCarlo/@ParticleWalker/private/one_dt.m
@@ -72,7 +72,7 @@ while norm(dxdydz, 2) > ZERO
                 % Fieremans et al, 2010, NMR Biomed.
                 % Monte Carlo study of a two-compartment exchange model of diffusion
                 % DOI:10.1002/nbm.1577
-                ds = norm(dxdydz, 2)*intersectInfo.t; % distance to membrane
+                ds = computeNormalDistance(intersectInfo.vertices, dxdydz_toIntersection);
                 term = (2 * ds * substrate.kappa)/D_old;
                 probability_of_transit = term/(1+term);
             otherwise
@@ -118,5 +118,24 @@ while norm(dxdydz, 2) > ZERO
     position(1, 4) = myoIndex;
 
 end
+
+end
+
+function distance = computeNormalDistance(faceVertices, step)
+% Find the projected distance in the normal direction to the plane
+
+V1 = faceVertices(1, :);
+V2 = faceVertices(2, :);
+V3 = faceVertices(3, :);
+edge01 = V2 - V1;
+edge02 = V3 - V1;
+normal = Geometry.crossFast2(edge01, edge02);
+normal = normal/norm(normal, 2);
+step_normalized = step/norm(step, 2);
+angle_between_vectors = acos(dot(step_normalized, normal));
+if angle_between_vectors >= pi/2
+    angle_between_vectors = pi - angle_between_vectors;
+end
+distance = norm(step,2)*cos(angle_between_vectors);
 
 end


### PR DESCRIPTION
As per [(Fieremans 2010), Appendix 1](https://onlinelibrary.wiley.com/doi/full/10.1002/nbm.1577#app1-title):

> Extension onto higher dimensions can be derived from the 1D case by assuming that the displacement during the time step dt is very small, such that the membrane surface can be considered to be flat. Equations [35] and [36] are derived from eqn [46] by replacing dx<sub>–</sub> by the corresponding normal distance ds to the membrane, and D<sub>–</sub> by the free diffusion coefficient in ICS and ECS, respectively.
