### PR TITLE
Add diffusion tensor support

### DIFF
--- a/+MRI/@DiffusionTensor/DiffusionTensor.m
+++ b/+MRI/@DiffusionTensor/DiffusionTensor.m
@@ -1,0 +1,11 @@
+% bare minimum classdef required to read DiffusionTensor from .mat file
+classdef DiffusionTensor
+    properties
+        tensor(3, 3)
+    end
+    methods
+        function obj = DiffusionTensor(tensor)
+            obj.tensor = tensor;
+        end
+    end
+end

--- a/+MRI/@ScanSequence/ScanSequence.m
+++ b/+MRI/@ScanSequence/ScanSequence.m
@@ -23,10 +23,16 @@ classdef ScanSequence
 
     properties(Dependent)
         NT
+        bvalue
     end
     methods
         function [NT] = get.NT(obj)
             NT = length(obj.dt);
+        end
+        function [b] = get.bvalue(obj)
+            t = cumsum(obj.dt);
+            k = cumtrapz(t, obj.gG);
+            b = trapz(t, k.^2);
         end
     end
 

--- a/+MRI/@ScanSequence/create.m
+++ b/+MRI/@ScanSequence/create.m
@@ -9,8 +9,8 @@ function [sequence] = create(NT, dt_max, SeqName, varargin)
 
 switch upper(SeqName)
     case {'PGSE', 'STEAM'} % follow the same rules
-        [Gmax, alpha90, alphaRO, epsilon, Delta, delta] = parse(varargin, ...
-            {'Gmax', 'alpha90', 'alphaRO', 'epsilon', 'Delta', 'delta'});
+        [Gmax, alpha90, alphaRO, epsilon, Delta, delta, gamma] = parse(varargin, ...
+            {'Gmax', 'alpha90', 'alphaRO', 'epsilon', 'Delta', 'delta', 'gamma'});
         durations = [alpha90, ...
                      epsilon, delta, epsilon, ...
                      Delta-(2*epsilon+delta), ...
@@ -19,8 +19,8 @@ switch upper(SeqName)
         ids = [0, 1, 2, 3, 0, -1, -2, -3, 0];
         [dt, gG] = discretize(durations, ids, NT, dt_max, Gmax);
     case {'MCSE', 'M2SE'} % these two names are synonyms
-        [Gmax, alpha90, alphaRO, epsilon, delta1, delta2] = parse(varargin, ...
-            {'Gmax', 'alpha90', 'alphaRO', 'epsilon', 'delta1', 'delta2'});
+        [Gmax, alpha90, alphaRO, epsilon, delta1, delta2, gamma] = parse(varargin, ...
+            {'Gmax', 'alpha90', 'alphaRO', 'epsilon', 'delta1', 'delta2', 'gamma'});
         del1 = delta1+2*epsilon;
         del2 = delta2+2*epsilon;
         Delta = (del2*(-2*del1+epsilon) + del1*epsilon)/(del1-del2);
@@ -32,9 +32,12 @@ switch upper(SeqName)
         ids = [0, -1, -2, -3, 1, 2, 3, 0, -1, -2, -3, 1, 2, 3, 0];
         [dt, gG] = discretize(durations, ids, NT, dt_max, Gmax);
     otherwise % dummy sequence
+        gamma = 1;
         dt = ones(1, NT)*dt_max(1);
         gG = zeros(1, NT);
 end
+
+gG = gG*gamma; % apply gamma
 
 sequence = MRI.ScanSequence(dt, gG);
 

--- a/+MRI/process_signal.m
+++ b/+MRI/process_signal.m
@@ -1,0 +1,62 @@
+function [tensor, RMS] = process_signal(data, sequence)
+
+% combine IC and EC data from simulation
+phase = [data.phase_ECS; data.phase_ICS];
+displ = [data.displacement_ECS; data.displacement_ICS];
+
+% calculate diffusion tensor
+bvalue = sequence.bvalue;
+tensor = process_phase(phase, bvalue);
+tensor = MRI.DiffusionTensor(tensor);
+
+% calculate bulk diffusivity
+T = sum(sequence.dt); % NOT equal to Delta, because we don't have that displ data
+RMS = process_displacement(displ, T);
+
+end
+
+function [tensor] = process_phase(phase, bvalue)
+% get diffusion tensor
+
+% gradient sampling directions
+directions = [1,  1,  0;
+              1, -1,  0;
+              1,  0,  1;
+              1,  0, -1;
+              0,  1,  1;
+              0,  1, -1];
+
+ndirs = size(directions, 1);
+b_matrix = zeros(ndirs, 6);
+signal_ratio = zeros(ndirs, 1);
+for i = 1:ndirs
+    dir = directions(i, :); % [Gx, Gy, Gz]
+    % b-matrix (b_xx, b_yy, b_zz, b_xy, b_xz, b_yz)
+    b_matrix(i, :) = [dir([1, 2, 3]).^2, dir([1, 1, 2]).*dir([2, 3, 3])] * bvalue;
+    % attenuation vector
+    phi = sum(dir .* phase, 2); % combine components
+    signal_ratio(i) = abs(mean(exp(-1i*phi), 1)); %TODO: abs(mean(_)) vs mean(abs(_)) ?
+end
+
+% least squares solution
+A = b_matrix;
+b = log(signal_ratio);
+x = -lscov(A, b); % solve
+
+% assign tensor
+tensor = zeros(3, 3);
+tensor(tril(true(3))) = x([1, 4, 5, 2, 6, 3]); % assign the right spaces
+tensor(triu(true(3), +1)) = tensor(tril(true(3), -1)); % mirror over diagonal
+
+end
+
+function [RMS] = process_displacement(displacement, T)
+% get diffusivity from RMS displacement
+
+dim = size(displacement, 2);
+RMS.MD = mean(sum(displacement.^2, 2))/(2*dim*T); % Cartesian distance
+RMS.Dx = mean(displacement(:, 1).^2)/(2*T); % distance in x only
+RMS.Dy = mean(displacement(:, 2).^2)/(2*T); % distance in y only
+RMS.Dz = mean(displacement(:, 3).^2)/(2*T); % distance in z only
+
+end

--- a/config/sequence.yml
+++ b/config/sequence.yml
@@ -7,6 +7,8 @@ sequence:
   #PGSE:
   # ... # this would contain the parameters for the sequence PGSE
 
+  gamma: 267.5e-6  # rad/ms/mT
+
   # number of time steps
   N_t: 100
 

--- a/run_sim.m
+++ b/run_sim.m
@@ -28,6 +28,7 @@ if isfield(config.sequence, 'type')
     seq_type = config.sequence.type;
     if isfield(config.sequence, seq_type)
         seq_data = config.sequence.(seq_type);
+        seq_data.gamma = config.sequence.gamma;
     else
         seq_data = struct();
     end


### PR DESCRIPTION
Allows for direct processing of DTI tensor based on the simulation data.

## TODOs
- [x] Add dependent property `bvalue` to ScanSequence to compute b-value on demand from the sequence